### PR TITLE
CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env
+yarn.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 .env
 yarn.lock
-package-lock.json

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,6 +9,7 @@
  * The author of this code has no formal relationship with NewsAPI.org and does not
  * claim to have created any of the facilities provided by NewsAPI.org.
  */
+//GLOBALS
 
 require("core-js/modules/es.symbol");
 
@@ -92,15 +93,24 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
+function _readOnlyError(name) { throw new Error("\"" + name + "\" is read-only"); }
+
 var fetch = require('node-fetch'),
     qs = require('querystring'),
-    host = 'https://newsapi.org';
+    host = 'https://newsapi.org',
+    CORSProxyUrl = ''; // To be set by user if declared in options
+
 
 var API_KEY; // To be set by clients
 
 var NewsAPI = /*#__PURE__*/function () {
   function NewsAPI(apiKey) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
     _classCallCheck(this, NewsAPI);
+
+    var corsProxyUrl = options.corsProxyUrl;
+    CORSProxyUrl = (_readOnlyError("CORSProxyUrl"), corsProxyUrl ? corsProxyUrl : ''); //assigns to global
 
     if (!apiKey) throw new Error('No API key specified');
     API_KEY = apiKey;
@@ -250,7 +260,7 @@ function splitArgsIntoOptionsAndCallback(args) {
 
 function createUrlFromEndpointAndOptions(endpoint, options) {
   var query = qs.stringify(options);
-  var baseURL = "".concat(host).concat(endpoint);
+  var baseURL = "".concat(CORSProxyUrl).concat(host).concat(endpoint);
   return query ? "".concat(baseURL, "?").concat(query) : baseURL;
 }
 /**
@@ -263,9 +273,13 @@ function createUrlFromEndpointAndOptions(endpoint, options) {
 
 
 function getDataFromWeb(url, options, apiKey, cb) {
-  var useCallback = 'function' === typeof cb;
+  var useCallback = 'function' === typeof cb; // CORS Headers by default
+
   var reqOptions = {
-    headers: {}
+    'mode': 'cors',
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    }
   };
 
   if (apiKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,30 +10,36 @@
  * claim to have created any of the facilities provided by NewsAPI.org.
  */
 
+//GLOBALS
 const fetch = require('node-fetch'),
   qs = require('querystring'),
-  host = 'https://newsapi.org';
+  host = 'https://newsapi.org',
+  CORSProxyUrl = ''; // To be set by user if declared in options
 
 let API_KEY; // To be set by clients
 
 class NewsAPI {
-  constructor (apiKey) {
+  constructor(apiKey, options = {}) {
+
+    const { corsProxyUrl } = options;
+    CORSProxyUrl = corsProxyUrl ? corsProxyUrl : ''; //assigns to global
+
     if (!apiKey) throw new Error('No API key specified');
     API_KEY = apiKey;
     this.v2 = {
-      topHeadlines (...args) {
+      topHeadlines(...args) {
         const { params = { language: 'en' }, options, cb } = splitArgsIntoOptionsAndCallback(args);
         const url = createUrlFromEndpointAndOptions('/v2/top-headlines', params);
         return getDataFromWeb(url, options, API_KEY, cb);
       },
 
-      everything (...args) {
+      everything(...args) {
         const { params, options, cb } = splitArgsIntoOptionsAndCallback(args);
         const url = createUrlFromEndpointAndOptions('/v2/everything', params);
         return getDataFromWeb(url, options, API_KEY, cb);
       },
 
-      sources (...args) {
+      sources(...args) {
         const { params, options, cb } = splitArgsIntoOptionsAndCallback(args);
         const url = createUrlFromEndpointAndOptions('/v2/sources', params);
         return getDataFromWeb(url, options, API_KEY, cb);
@@ -41,13 +47,13 @@ class NewsAPI {
     }
   }
 
-  sources (...args) {
+  sources(...args) {
     const { params, options, cb } = splitArgsIntoOptionsAndCallback(args);
     const url = createUrlFromEndpointAndOptions('/v1/sources', params);
     return getDataFromWeb(url, options, null, cb);
   }
 
-  articles (...args) {
+  articles(...args) {
     const { params, options, cb } = splitArgsIntoOptionsAndCallback(args);
     const url = createUrlFromEndpointAndOptions('/v1/articles', params);
     return getDataFromWeb(url, options, API_KEY, cb);
@@ -68,7 +74,7 @@ class NewsAPIError extends Error {
  * @param {Array}   args The arguments to the function
  * @return {Object}
  */
-function splitArgsIntoOptionsAndCallback (args) {
+function splitArgsIntoOptionsAndCallback(args) {
   let params;
   let options;
   let cb;
@@ -96,9 +102,9 @@ function splitArgsIntoOptionsAndCallback (args) {
  * @param {Object} [options]
  * @return {String}
  */
-function createUrlFromEndpointAndOptions (endpoint, options) {
+function createUrlFromEndpointAndOptions(endpoint, options) {
   const query = qs.stringify(options);
-  const baseURL = `${host}${endpoint}`;
+  const baseURL = `${CORSProxyUrl}${host}${endpoint}`;
   return query ? `${baseURL}?${query}` : baseURL;
 }
 
@@ -111,7 +117,8 @@ function createUrlFromEndpointAndOptions (endpoint, options) {
  */
 function getDataFromWeb(url, options, apiKey, cb) {
   let useCallback = 'function' === typeof cb;
-  const reqOptions = { headers: {} };
+  // CORS Headers by default
+  const reqOptions = { 'mode': 'cors', headers: { 'Access-Control-Allow-Origin': '*' } };
   if (apiKey) {
     reqOptions.headers['X-Api-Key'] = apiKey;
   }


### PR DESCRIPTION
_I was having problems with and had to rebase_

---
Added this to default request options, this might enable CORS in most enviroments
```js
const reqOptions = { 'mode': 'cors', headers: { 'Access-Control-Allow-Origin': '*' } };
``` 

Also you can now set a CORS proxy url in an options parameter if above option is not working

Example:
```js
const NewsAPI = require('newsapi');
const newsapi = new NewsAPI('YOUR_API_KEY', { corsProxyUrl: 'https://cors-anywhere.herokuapp.com/' });
```Added this to default request options, this might enable CORS in most enviroments
```js
const reqOptions = { 'mode': 'cors', headers: { 'Access-Control-Allow-Origin': '*' } };
``` 

Also you can now set a CORS proxy url in an options parameter if above option is not working

Example:
```js
const NewsAPI = require('newsapi');
const newsapi = new NewsAPI('YOUR_API_KEY', { corsProxyUrl: 'https://cors-anywhere.herokuapp.com/' });
```